### PR TITLE
T4952: install list_interfaces to completion directory

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,6 +21,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p $(DIR)/usr/libexec/vyos/validators
+	mkdir -p $(DIR)/usr/libexec/vyos/completion
 	cp _build/numeric $(DIR)/usr/libexec/vyos/validators
 	cp _build/validate-value $(DIR)/usr/libexec/vyos/
 	cp _build/file-path $(DIR)/usr/libexec/vyos/validators

--- a/debian/vyos-utils.install
+++ b/debian/vyos-utils.install
@@ -2,3 +2,4 @@ usr/libexec/vyos/validate-value
 usr/libexec/vyos/validators/numeric
 usr/libexec/vyos/validators/file-path
 usr/libexec/vyos/validators/url
+usr/libexec/vyos/completion/list_interfaces


### PR DESCRIPTION
Add missing line to debian/vyos-utils.install.