### PR TITLE
T5882: use Dune as build system

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,26 +7,17 @@ DIR := debian/tmp
 
 override_dh_auto_build:
 	eval `opam env`
-	mkdir -p _build
-	ocamlfind ocamlopt -o _build/numeric -package pcre -linkpkg src/numeric.ml
-	ocamlfind ocamlopt -o _build/file-path -package fileutils -linkpkg src/file_path.ml
-	ocamlfind ocamlopt -o _build/url -package pcre -linkpkg src/url.ml
-	ocamlfind ocamlopt -o _build/validate-value -package pcre,unix,containers -linkpkg src/validate_value.ml
-#   list_interfaces
-	ocamlfind ocamlopt -c src/iface/func.mli
-	ocamlfind ocamlopt -I src/iface -c src/iface/func.ml
-	ocamlfind ocamlopt -I src/iface -c src/iface/iface.c
-	ocamlfind ocamlopt -I src/iface -package pcre -c src/iface/list_interfaces.ml
-	ocamlfind ocamlopt -I src/iface func.cmx iface.o list_interfaces.cmx -o _build/list_interfaces -package pcre -linkpkg
+	dune clean
+	dune build
 
 override_dh_auto_install:
 	mkdir -p $(DIR)/usr/libexec/vyos/validators
 	mkdir -p $(DIR)/usr/libexec/vyos/completion
-	cp _build/numeric $(DIR)/usr/libexec/vyos/validators
-	cp _build/validate-value $(DIR)/usr/libexec/vyos/
-	cp _build/file-path $(DIR)/usr/libexec/vyos/validators
-	cp _build/url $(DIR)/usr/libexec/vyos/validators
-	cp _build/list_interfaces $(DIR)/usr/libexec/vyos/completion
+	cp _build/install/default/bin/numeric $(DIR)/usr/libexec/vyos/validators
+	cp _build/install/default/bin/validate-value $(DIR)/usr/libexec/vyos/
+	cp _build/install/default/bin/file-path $(DIR)/usr/libexec/vyos/validators
+	cp _build/install/default/bin/url $(DIR)/usr/libexec/vyos/validators
+	cp _build/install/default/bin/list_interfaces $(DIR)/usr/libexec/vyos/completion
 
 override_dh_auto_test:
 	echo "No tests yet"

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 2.0)
+(name vyos-utils)

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,34 @@
+(include_subdirs unqualified)
+
+(executable
+ (name numeric)
+ (public_name numeric)
+ (modules numeric)
+ (libraries pcre))
+
+(executable
+ (name url)
+ (public_name url)
+ (modules url)
+ (libraries pcre))
+
+(executable
+ (name file_path)
+ (public_name file-path)
+ (modules file_path)
+ (libraries fileutils))
+
+(executable
+ (name validate_value)
+ (public_name validate-value)
+ (modules validate_value)
+ (libraries pcre unix containers))
+
+(executable
+ (name list_interfaces)
+ (public_name list_interfaces)
+ (modules func list_interfaces)
+ (libraries pcre)
+ (foreign_stubs
+  (language c)
+  (names iface)))

--- a/vyos-utils.opam
+++ b/vyos-utils.opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+name: "vyos-utils"
+version: "0.0.3"
+synopsis: "VyOS utils"
+description: """
+A collection of validators and completion helpers.
+"""
+maintainer: "Daniil Baturin <daniil@baturin.org>"
+authors: "VyOS maintainers and contributors <maintainers@vyos.net>"
+license: "MIT"
+homepage: "https://github.com/vyos/vyos-utils"
+bug-reports: "https://phabricator.vyos.net"
+dev-repo: "git+https://github.com/vyos/vyos-utils/"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name]
+]
+depends: [
+  "ocamlfind" {build}
+  "dune" {build & >= "2.0"}
+]


### PR DESCRIPTION
Move to Dune as build system. The main build file remains verbose, as each executable must be separated by stanza to limit included files and linked libraries; on the other hand, the inclusion of the foreign C stub is simplified, and we are using the current standard for building.