### PR TITLE
T5069: warning in validator not visible without failure

### DIFF
--- a/src/validate_value.ml
+++ b/src/validate_value.ml
@@ -19,7 +19,7 @@ let rec validate_value buf value_constraint value =
        especially when the input comes directly from the user...
        We should do something about it.
      *)
-    let chan = Unix.open_process_in (Printf.sprintf "%s \'%s\' 2>&1" c value) in
+    let chan = Unix.open_process_in (Printf.sprintf "%s \'%s\'" c value) in
     let out = try CCIO.read_all chan with _ -> "" in
     let result = Unix.close_process_in chan in
     match result with


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
In my [related PR](https://github.com/vyos/vyos-1x/pull/4482) against vyos-1x, I'm adding a sanity-check warning to the bgp-large-community-list validator, but the output is eaten by validate_value. 

This change allows validator scripts to request visible output, without completely failing validation. It prints results immediately rather than messing with `buf` and flagging output at the end, I don't know OCaml well. 

Please advise if this change should also be applied to vyos1x-config or if a different method should be used, such as a regex over validator output. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5069

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4482

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
