### PR TITLE
validators: T7450: use PCRE2 instead of the outdated original PCRE

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,7 @@ Section: contrib/net
 Priority: extra
 Maintainer: VyOS Package Maintainers <maintainers@vyos.net>
 Build-Depends: debhelper (>= 9),
-  quilt,
-  libpcre3-dev,
+  quilt
 Standards-Version: 3.9.6
 
 Package: vyos-utils

--- a/src/completion/list_interfaces/list_interfaces.ml
+++ b/src/completion/list_interfaces/list_interfaces.ml
@@ -44,10 +44,10 @@ let type_to_prefix it =
 
 (* filter_section to match the constraint of python.vyos.ifconfig.section
  *)
-let rx = Pcre.regexp {|\d(\d|v|\.)*$|}
+let rx = Pcre2.regexp {|\d(\d|v|\.)*$|}
 
 let filter_section s =
-    let r = Pcre.qreplace_first ~rex:rx ~templ:"" s in
+    let r = Pcre2.qreplace_first ~rex:rx ~templ:"" s in
     match r with
     |"bond"|"br"|"dum"|"eth"|"gnv"|"ifb"|"l2tpeth"|"lo"|"macsec" -> true
     |"peth"|"pppoe"|"sstpc"|"tun"|"veth"|"vti"|"vtun"|"vxlan"|"wg"|"wlan"|"wwan" -> true
@@ -57,7 +57,7 @@ let filter_from_prefix p s =
     let pattern = Printf.sprintf "^%s(.*)$" p
     in
     try
-        let _ = Pcre.exec ~pat:pattern s in
+        let _ = Pcre2.exec ~pat:pattern s in
         true
     with Not_found -> false
 
@@ -71,7 +71,7 @@ let filter_broadcast s =
     let pattern = {|^(bond|br|tun|vtun|eth|gnv|peth|macsec|vxlan|wwan|wlan)(.*)$|}
     in
     try
-        let _ = Pcre.exec ~pat:pattern s in
+        let _ = Pcre2.exec ~pat:pattern s in
         true
     with Not_found -> false
 
@@ -79,7 +79,7 @@ let filter_bridgeable s =
     let pattern = {|^(bond|eth|gnv|l2tpeth|lo|tun|veth|vtun|vxlan|wlan)(.*)$|}
     in
     try
-        let _ = Pcre.exec ~pat:pattern s in
+        let _ = Pcre2.exec ~pat:pattern s in
         true
     with Not_found -> false
 
@@ -87,7 +87,7 @@ let filter_bondable s =
     let pattern = {|^(eth)(.*)$|}
     in
     try
-        let _ = Pcre.exec ~pat:pattern s in
+        let _ = Pcre2.exec ~pat:pattern s in
         true
     with Not_found -> false
 
@@ -95,7 +95,7 @@ let filter_no_vlan s =
     let pattern = {|^([^.]+)(\.\d+)+$|}
     in
     try
-        let _ = Pcre.exec ~pat:pattern s in
+        let _ = Pcre2.exec ~pat:pattern s in
         false
     with Not_found -> true
 

--- a/src/dune
+++ b/src/dune
@@ -4,13 +4,13 @@
  (name numeric)
  (public_name numeric)
  (modules numeric)
- (libraries pcre))
+ (libraries pcre2))
 
 (executable
  (name url)
  (public_name url)
  (modules url)
- (libraries pcre))
+ (libraries pcre2))
 
 (executable
  (name file_path)
@@ -22,13 +22,13 @@
  (name validate_value)
  (public_name validate-value)
  (modules validate_value)
- (libraries pcre unix containers))
+ (libraries pcre2 unix containers))
 
 (executable
  (name list_interfaces)
  (public_name list_interfaces)
  (modules func list_interfaces)
- (libraries pcre)
+ (libraries pcre2)
  (foreign_stubs
   (language c)
   (names iface)))

--- a/src/validate_value.ml
+++ b/src/validate_value.ml
@@ -12,14 +12,16 @@ let rec validate_value buf value_constraint value =
   | Group l ->
     List.for_all (fun c -> validate_value buf c value) l
   | Regex s ->
-    (try let _ = Pcre.exec ~pat:(Printf.sprintf "^%s$" s) value in true
+    (try let _ = Pcre2.exec ~pat:(Printf.sprintf "^%s$" s) value in true
      with Not_found -> false)
   | Exec c ->
     (* XXX: Unix.open_process_in is "shelling out", which is a bad idea on multiple levels,
        especially when the input comes directly from the user...
        We should do something about it.
      *)
-    let chan = Unix.open_process_in (Printf.sprintf "%s \'%s\' 2>&1" c value) in
+    let cmd = Printf.sprintf "%s \'%s\' 2>&1" c value in
+    let () = Printf.printf "COMMAND: %s" cmd in
+    let chan = Unix.open_process_in cmd in
     let out = try CCIO.read_all chan with _ -> "" in
     let result = Unix.close_process_in chan in
     match result with

--- a/src/validators/numeric.ml
+++ b/src/validators/numeric.ml
@@ -65,11 +65,11 @@ let check_positive opts m =
         failwith "option '--positive does' not apply to a range value"
 
 let looks_like_number value =
-  try let _ = Pcre.exec ~pat:"^(\\-?)[0-9]+(\\.[0-9]+)?$" value in true
+  try let _ = Pcre2.exec ~pat:"^(\\-?)[0-9]+(\\.[0-9]+)?$" value in true
   with Not_found -> false
 
 let is_relative value =
-  try let _ = Pcre.exec ~pat:"^[+-][0-9]+$" value in true
+  try let _ = Pcre2.exec ~pat:"^[+-][0-9]+$" value in true
   with Not_found -> false
 
 let number_string_drop_modifier value =
@@ -170,7 +170,7 @@ let check_argument_type opts m =
     else Printf.ksprintf failwith "Value must be a number, not a range"
 
 let is_range_val s =
-  try let _ = Pcre.exec ~pat:"^[0-9]+-[0-9]+$" s in true
+  try let _ = Pcre2.exec ~pat:"^[0-9]+-[0-9]+$" s in true
   with Not_found -> false
 
 let var_numeric_str s =

--- a/src/validators/url.ml
+++ b/src/validators/url.ml
@@ -9,9 +9,9 @@
  *)
 let split_scheme url =
   let aux url =
-    let res = Pcre.exec ~pat:{|^([a-zA-Z0-9\.\-]+):(.*)$|} url in
-    let scheme = Pcre.get_substring res 1 in
-    let uri = Pcre.get_substring res 2 in
+    let res = Pcre2.exec ~pat:{|^([a-zA-Z0-9\.\-]+):(.*)$|} url in
+    let scheme = Pcre2.get_substring res 1 in
+    let uri = Pcre2.get_substring res 2 in
     (String.lowercase_ascii scheme, uri)
   in
   try Ok (aux url)
@@ -24,17 +24,17 @@ let is_scheme_allowed allowed_schemes scheme =
 
 let regex_matches regex s =
   try
-    let _ = Pcre.exec ~rex:regex s in
+    let _ = Pcre2.exec ~rex:regex s in
     true
   with Not_found -> false
 
 let host_path_format =
-  Pcre.regexp
+  Pcre2.regexp
   {|^//(?:[^/?#]+(?::[^/?#]*)?@)?([a-zA-Z0-9\-\._~]+|\[[a-zA-Z0-9:\.]+\])(?::([0-9]+))?(/.*)?$|}
 
-let host_name_format = Pcre.regexp {|^[a-zA-Z0-9]+([\-\._~]{1}[a-zA-Z0-9]+)*$|}
-let ipv4_addr_format = Pcre.regexp {|^(([1-9]\d{0,2}|0)\.){3}([1-9]\d{0,2}|0)$|}
-let ipv6_addr_format = Pcre.regexp {|^\[([a-z0-9:\.]+|[A-Z0-9:\.]+)\]$|}
+let host_name_format = Pcre2.regexp {|^[a-zA-Z0-9]+([\-\._~]{1}[a-zA-Z0-9]+)*$|}
+let ipv4_addr_format = Pcre2.regexp {|^(([1-9]\d{0,2}|0)\.){3}([1-9]\d{0,2}|0)$|}
+let ipv6_addr_format = Pcre2.regexp {|^\[([a-z0-9:\.]+|[A-Z0-9:\.]+)\]$|}
 
 let is_port s =
   try
@@ -58,8 +58,8 @@ let is_ipv6_segment s =
   with Failure _ -> false
 
 let is_ipv4_addr s =
-  let res = Pcre.exec ~rex:ipv4_addr_format s in
-  let ipv4_addr_str = Pcre.get_substring res 0 in
+  let res = Pcre2.exec ~rex:ipv4_addr_format s in
+  let ipv4_addr_str = Pcre2.get_substring res 0 in
   let ipv4_addr_l = String.split_on_char '.' ipv4_addr_str in
   List.for_all is_ipv4_octet ipv4_addr_l
 
@@ -83,10 +83,10 @@ let is_ipv6_dual_addr s =
           List.for_all is_ipv6_segment seg_str_l
 
 let is_ipv6_addr s =
-  let res = Pcre.exec ~rex:ipv6_addr_format s in
-  let ipv6_addr_str = Pcre.get_substring res 1 in
+  let res = Pcre2.exec ~rex:ipv6_addr_format s in
+  let ipv6_addr_str = Pcre2.get_substring res 1 in
   try
-    let typo = Pcre.exec ~pat:{|:::|} ipv6_addr_str in
+    let typo = Pcre2.exec ~pat:{|:::|} ipv6_addr_str in
     match typo with
     | _ -> false
   with Not_found ->
@@ -94,8 +94,8 @@ let is_ipv6_addr s =
 
 let host_path_matches s =
   try
-    let res = Pcre.exec ~rex:host_path_format s in
-    let substr = Pcre.get_substrings ~full_match:false res in
+    let res = Pcre2.exec ~rex:host_path_format s in
+    let substr = Pcre2.get_substrings ~full_match:false res in
     let port_str = Array.get substr 1 in
     if String.length port_str > 0 && not (is_port port_str) then false
     else


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Value validation utilities currently use the [pcre](https://opam.ocaml.org/packages/pcre/) OCaml package. That package is based on the original PCRE library. Its latest release 8.45 is the last release and the original implementation is now declared EOL. That package is named [libpcre3 in Debian](https://github.com/ocaml/opam-repository/blob/master/packages/conf-libpcre/conf-libpcre.2/opam#L23), for some reason.

PCRE maintainers made a new release line called PCRE2 that has now replaced the original. Debian Trixie no longer includes the original implementation, only PCRE2. The package is called [libpcre2](https://github.com/ocaml/opam-repository/blob/master/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam#L26). Yes, you read it right: libpcre2 is _newer_ than libpcre3.

There are already [OCaml bindings for PCRE2](https://opam.ocaml.org/packages/pcre2/) — they are API-compatible, just use a different module name, so we only need to update those names and dependencies to make it work.

I also removed the build dependency from `debian/control` — that file doesn't list actual build dependencies like the OCaml toolchain anyway, so it's no use keeping libpcre there.

libpcre2 does exist in Debian Bookworm, so we can backport this change to 1.5/Circinus and possibly to 1.4/Sagitta.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): dependency update.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
