### PR TITLE
T7758: allow repeated option --type in list_interfaces

### DIFF
--- a/src/completion/list_interfaces/list_interfaces.ml
+++ b/src/completion/list_interfaces/list_interfaces.ml
@@ -1,13 +1,13 @@
 (*
  *)
-let intf_type = ref ""
+let intf_types = ref []
 let broadcast = ref false
 let bridgeable = ref false
 let bondable = ref false
 let no_vlan = ref false
 
 let args = [
-    ("--type", Arg.String (fun s -> intf_type := s), "List interfaces of specified type");
+    ("--type", Arg.String (fun s -> intf_types := (s :: !intf_types)), "List interfaces of specified type");
     ("--broadcast", Arg.Unit (fun () -> broadcast := true), "List broadcast interfaces");
     ("--bridgeable", Arg.Unit (fun () -> bridgeable := true), "List bridgeable interfaces");
     ("--bondable", Arg.Unit (fun () -> bondable := true), "List bondable interfaces");
@@ -99,8 +99,7 @@ let filter_no_vlan s =
         false
     with Not_found -> true
 
-let get_interfaces =
-    let intf_type = !intf_type in
+let get_interfaces_by_type out intf_type =
     let fltr =
     if String.length(intf_type) > 0 then
         filter_from_type intf_type
@@ -124,10 +123,16 @@ let get_interfaces =
         if !no_vlan then List.filter filter_no_vlan res
         else res
     in
-    let res = List.filter filter_section res in
-    match fltr with
-    | Some f -> List.filter f res
-    | None -> res
+    let add_out =
+        let res = List.filter filter_section res in
+        match fltr with
+        | Some f -> List.filter f res
+        | None -> res
+    in List.append out add_out
+
+let get_interfaces =
+    let types = List.rev !intf_types in
+    List.fold_left get_interfaces_by_type [] types
 
 let () =
   let res = get_interfaces in


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Feature request: simple extension to allow repeated option `--type`:

```
vyos@vyos:/usr/libexec/vyos/completion$ ./list_interfaces --type ethernet --type dummy
eth0 eth1 eth2 eth3 dum0 dum1

```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
