### PR TITLE
T8269: add option to silence output of individual validators

### DIFF
--- a/src/validate_value.ml
+++ b/src/validate_value.ml
@@ -4,6 +4,7 @@ type check = Regex of string | Exec of string | Group of check list
 let options = ref []
 let checks = ref []
 let value = ref ""
+let silent = ref false
 
 let buf = Buffer.create 4096
 
@@ -36,6 +37,7 @@ let args = [
   ("--regex", Arg.String (fun s -> options := (RegexOpt s) :: !options), "Check the value against a regex");
   ("--exec", Arg.String (fun s -> options := (ExecOpt s) :: !options), "Check the value against an external command");
   ("--grp", Arg.Unit (fun () -> options := (GroupSeparator) :: !options), "Group following arguments, combining results with logical and");
+  ("--silent", Arg.Unit (fun () -> silent := true), "Suppress individual validator output");
   ("--value", Arg.String (fun s -> value := s), "Value to check");
 ]
 let usage = Printf.sprintf "Usage: %s [OPTIONS] <number>" Sys.argv.(0)
@@ -105,5 +107,6 @@ let _ =
     (* If we got this far, value validation failed.
        Show the user output from the validators.
      *)
-    Buffer.contents buf |> print_endline;
+    if not !silent then Buffer.contents buf |> print_endline
+    else ();
     exit 1


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add option to suppress error output of individual validators. This is useful when one would prefer a global constraintErrorMessage over multiple, perhaps misleading, error messages. Cf. example in https://vyos.dev/T8269:

```
vyos@vyos# set protocols bgp neighbor 172.18.20

  Incorrect path /sys/class/net/172.18.20: no such file or directory

  Error: 172.18.20 is not a valid IP address



  Invalid value
  Value validation failed
  Set failed

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): add useful option

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
