### PR TITLE
T8795: replace inline Mergify config with extends: mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,10 +1,3 @@
-pull_request_rules:
-  - name: Label conflicting pull requests
-    description: Add a label to a pull request with conflict to spot it easily
-    conditions:
-      - conflict
-      - '-closed'
-    actions:
-      label:
-        toggle:
-          - conflicts
+extends: mergify
+merge_protections_settings:
+  reporting_method: check-runs


### PR DESCRIPTION
Replaces the inline per-repo `.github/mergify.yml` with `extends: mergify` central-baseline inheritance + explicit `merge_protections_settings.reporting_method: check-runs` (Mergify deprecation deadline 2026-07-31, [T8925](https://vyos.dev/T8925)).

The previous file duplicated the central baseline's `commands_restrictions` + `Label conflicting pull requests` rule — now inherited via `extends:`.

Finishes [T8782](https://vyos.dev/T8782) subtask [T8795](https://vyos.dev/T8795); part of [T8852](https://vyos.dev/T8852) fleet migration.

🤖 Generated by [robots](https://vyos.io)